### PR TITLE
fix: 로또번호 라인의 맨 앞에 "가, 나, 다" 대신 1,2,3 으로 변경해줘.

### DIFF
--- a/src/lib/lotto.ts
+++ b/src/lib/lotto.ts
@@ -50,6 +50,5 @@ export function calculateFrequency(games: LottoGame[]): NumberFrequency[] {
 }
 
 export function formatGameLabel(index: number): string {
-  const labels = ["가", "나", "다", "라", "마", "바", "사", "아", "자", "차"];
-  return labels[index] || String(index + 1);
+  return String(index + 1);
 }


### PR DESCRIPTION
Closes #4