### PR TITLE
fix: hydration mismatch 오류 수정 (#7)

### DIFF
--- a/src/components/lotto/LottoApp.tsx
+++ b/src/components/lotto/LottoApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { LottoGame } from "@/types/lotto";
 import {
   generateLottoNumbers,
@@ -20,9 +20,11 @@ import { toast } from "sonner";
 const DEFAULT_GAME_COUNT = 5;
 
 export function LottoApp() {
-  const [games, setGames] = useState<LottoGame[]>(() =>
-    generateMultipleGames(DEFAULT_GAME_COUNT)
-  );
+  const [games, setGames] = useState<LottoGame[]>([]);
+
+  useEffect(() => {
+    setGames(generateMultipleGames(DEFAULT_GAME_COUNT));
+  }, []);
 
   const handleGenerateAll = useCallback(() => {
     setGames(generateMultipleGames(DEFAULT_GAME_COUNT));


### PR DESCRIPTION
Closes #7

## 변경 사항

 컴포넌트에서 `useState` 초기값으로 `generateMultipleGames()`를 직접 호출하면 SSR 시와 클라이언트 hydration 시 `Math.random()`, `crypto.randomUUID()` 값이 달라져 hydration 불일치가 발생합니다.

**수정 내용:**
- `useState` 초기값을 빈 배열 `[]`로 변경
- `useEffect`를 사용해 클라이언트 마운트 후 게임 데이터를 생성

이로써 서버와 클라이언트가 동일한 초기 상태(빈 배열)로 렌더링되어 hydration 오류가 해결됩니다.